### PR TITLE
Lots of small revisions

### DIFF
--- a/.github/workflows/isort-and-black-checks.yml
+++ b/.github/workflows/isort-and-black-checks.yml
@@ -9,11 +9,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          python-version: 3.14
       - name: Install click, black and isort
         run: pip install 'click==8.2.1' 'black==25.11.0' 'isort==5.13.2'
       - name: Run isort --check .

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,13 +19,20 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install Mathics3 Pygments dependencies
       run: |
-        python -m pip install --upgrade pip
+        # We can comment out after next Mathics3-Scanner release
+        # python -m pip install -e git+https://github.com/Mathics3/Mathics3-scanner#egg=Mathics3-Scanner[full]
+        git clone --depth 1 https://github.com/Mathics3/Mathics3-scanner.git
+        cd Mathics3-scanner/
+        pip install -e .
+        bash -x admin-tools/make-JSON-tables.sh
+        cd ..
     - name: Install Mathics3 Pygments
       run: |
-        pip install -e .
-    - name: Test Mathics Pygments
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --no-build-isolation -e .
+    - name: Test Mathics3 Pygments
       run: |
         pip install pytest
         make check

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: mathics-pygments (OSX)
+name: mathics-pygments (MacOS)
 
 on:
   push:
@@ -12,17 +12,17 @@ jobs:
     strategy:
       matrix:
         os: [macOS]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.14', '3.13', '3.12']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-    - name: Install Mathics Pygments
+    - name: Install Mathics3 Pygments
       run: |
         pip install -e .
     - name: Test Mathics Pygments

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,20 +11,27 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.14', '3.11', '3.12', '3.13']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install Mathics3 Pygments dependencies
       run: |
-        python -m pip install --upgrade pip
-    - name: Install Mathics Pygments
-      run: |
+        # We can comment out after next Mathics3-Scanner release
+        # python -m pip install -e git+https://github.com/Mathics3/Mathics3-scanner#egg=Mathics3-Scanner[full]
+        git clone --depth 1 https://github.com/Mathics3/Mathics3-scanner.git
+        cd Mathics3-scanner/
         pip install -e .
-    - name: Test Mathics Pygments
+        bash -x admin-tools/make-JSON-tables.sh
+        cd ..
+    - name: Install Mathics3 Pygments
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --no-build-isolation -e .
+    - name: Test Mathics3 Pygments
       run: |
         pip install pytest
         make check

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,20 +12,27 @@ jobs:
     strategy:
       matrix:
         os: [windows]
-        python-version: ['3.9', '3.11']
+        python-version: ['3.11', '3.14']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install Mathics3 Pygments dependencies
       run: |
-        python -m pip install --upgrade pip
-    - name: Install Mathics Pygments
+        # We can comment out after next Mathics3-Scanner release
+        # python -m pip install -e git+https://github.com/Mathics3/Mathics3-scanner#egg=Mathics3-Scanner[full]
+        git clone --depth 1 https://github.com/Mathics3/Mathics3-scanner.git
+        cd Mathics3-scanner/
+        pip install -e .
+        bash -x admin-tools/make-JSON-tables.sh
+        cd ..
+    - name: Install Mathics3 Pygments
       run: |
-        python setup.py install
-    - name: Test Mathics Pygments
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --no-build-isolation -e .
+    - name: Test Mathics3 Pygments
       run: |
         pip install pytest
         make check

--- a/mathics_pygments/builtins.py
+++ b/mathics_pygments/builtins.py
@@ -6551,7 +6551,7 @@ SYSTEM_SYMBOLS = {
 }
 
 # The Mathics parser can't handle Degree ("uB0") as an operator, so we'll add it here.
-UNICODE_OPERATORS = set(list(_data["unicode-operators"].keys()) + ["\u00B0"])
+UNICODE_OPERATORS = set(list(_data["unicode-operators"].keys()) + ["\u00b0"])
 
 UNICODE_OPERATORS_OLD = {
     "·",  # \[CenterDot]

--- a/mathics_pygments/version.py
+++ b/mathics_pygments/version.py
@@ -5,4 +5,4 @@
 # space around "=" below.
 
 # fmt: off
-__version__="1.0.4"  # noqa
+__version__="10.0.0"  # noqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,66 @@
+[build-system]
+requires = [
+    "setuptools>=70.0.0", # CVE-2024-38335 recommends this
+    # needed for building tables for the sdist:
+    "PyYAML",
+    "click",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "Mathics3_pygments"
+description = "Mathics3/Mathematica/Wolfram Language Lexer for Pygments"
+dependencies = [
+    "Pygments >= 2.9",     # Used in mathics-generate-json-table
+    "Mathics3_Scanner>9.0",
+    "click",      # Using in CLI: build_pygments_tables.py
+]
+requires-python = ">=3.11"
+readme = "README.rst"
+license = "MIT"
+keywords = ["Mathematica", "Syntax highlighting"]
+maintainers = [
+    {name = "Mathics3 Group"},
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: End Users/Desktop",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Topic :: Text Processing",
+]
+dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://mathics.org/"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+]
+
+
+[tool.setuptools]
+packages = [
+    "mathics_pygments",
+]
+
+[tool.setuptools.package-data]
+"mathics_pygments" = [
+    "data/named-characters.yml",
+    "data/*.csv",
+    "data/characters.json",  # List this explicitly since it is needed
+    "data/*.json",
+    "data/ExampleData/*",
+]
+
+[tool.setuptools.dynamic]
+version = {attr = "mathics_pygments.version.__version__"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Pygments>=2.1
 wheel==0.38.1
-Mathics_Scanner
+Mathics3_Scanner

--- a/setup.py
+++ b/setup.py
@@ -21,80 +21,14 @@ It currently supports:
 A Sass file containing the styles can be obtained from the package repository for use in static \
 website generators such as Jekyll, Octopress, Pelican, etc.
 
-Copyright 2021, 2024 Rocky Bernstein
+Copyright 2021, 2024, 2026 Rocky Bernstein
 (C) 2016 rsmenon
 """
 
-import sys
+from setuptools import find_packages, setup
 
-from setuptools import setup
-
-# Ensure user has the correct Python version
-if sys.version_info < (3, 6):
-    print("mathicsscript does not support Python %d.%d" % sys.version_info[:2])
-    sys.exit(-1)
-
-
-import os.path as osp
-
-
-def get_srcdir():
-    filename = osp.normcase(osp.dirname(osp.abspath(__file__)))
-    return osp.realpath(filename)
-
-
-def read(*rnames):
-    return open(osp.join(get_srcdir(), *rnames)).read()
-
-
-# stores __version__ in the current namespace
-exec(
-    compile(read("mathics_pygments/version.py"), "mathics_pygments/version.py", "exec")
-)
-
-setup(
-    name="mathics_pygments",
-    version=__version__,  # noqa
-    description="Mathematica/Wolfram Language Lexer for Pygments",
-    long_description=__doc__,
-    long_description_content_type="text/x-rst",
-    author="Rocky Bernstein",
-    author_email="rb@dustyfeet.com",
-    license="MIT",
-    keywords="syntax highlighting mathematica",
-    url="http://github.com/Mathics3/mathics-pygments/",
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: End Users/Desktop",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Topic :: Text Processing",
-        "Topic :: Utilities",
-    ],
-    packages=["mathics_pygments"],
-    package_data={
-        "mathics_pygments": [
-            "data/mma-tables.json",
-        ],
-    },
-    install_requires=["Pygments >= 2.9.0", "Mathics_Scanner>=1.3.0"],
-    include_package_data=False,
-    platforms=["any"],
-    entry_points={
-        "pygments.lexers": ["MathematicaLexer = mathics_pygments:MathematicaLexer"],
-        "pygments.styles": [
-            "mathematica = mathics_pygments:MathematicaStyle",
-            "mathematicanotebook = mathics_pygments:MathematicaNotebookStyle",
-        ],
-    },
-    zip_safe=False,
-)
+if __name__ == "__main__":
+    setup(
+        packages=find_packages(),
+        include_package_data=True,
+    )


### PR DESCRIPTION
* Package name is now `Mathics3_pygments`
* Track `Mathics3_scanner` package name change
* Bump Python packages version to 10x
* Start using `pyproject.toml`
* Supports Python 3.11-3.14 now
* Update versions in CI scripts.